### PR TITLE
dynamic readme with jinja2 and markdown

### DIFF
--- a/recipes/dep_cats_permits/README.md
+++ b/recipes/dep_cats_permits/README.md
@@ -1,0 +1,27 @@
+### **Common name of dataset**
+NYC DEP Clean Air Tracking System (CATS) Light Industrial Process Permit
+
+### **Tags**
+Light Industrial Permit, DEP CATS
+
+### **Summary**
+This dataset consists light industrial process permits registered with the NYC Department of Environmental Protection (DEP) and pulled from the DEP Clean Air Tracking System (CATS). For the full DEP CATS dataset, refer to https://data.cityofnewyork.us/Environment/CATSPermits/f4rp-2kvy
+
+### **Description**
+This dataset contains light industrial process permits registered with NYC DEP from the Clean Air Tracking System Data. Each row in the Excel spreadsheet contains a record of a light industrial process permit (permit records with P prefix) while the Shapefile provides a format that allows the user to import the data into mapping software. This information can be used to identify manufacturing or processing facilities within a 400 feet radius from the project site, as part of the preliminary stationary source screening analysis. If there are manufacturing or processing facilities within the 400 feet radius, further stationary source analysis may be needed to determine the effects of the sources on the project, requiring more detailed permit information.
+
+### **Credits**
+Department of Environmental Protection (DEP)
+
+### **Use limitations**
+NYC DEP Clean Air Tracking System (CATS) Light Industrial Process Permit is being provided by the Department of City Planning (DCP) on DCP's website for informational purposes only. DCP does not warranty the completeness, accuracy, content, or fitness for any particular purpose or use of NYC DEP Clean Air Tracking System (CATS) Light Industrial Process Permit, nor are any such warranties to be implied or inferred with respect to NYC DEP Clean Air Tracking System
+(CATS) Light Industrial Process Permit as furnished on the website. DCP and the City are not liable for any deficiencies in the completeness, accuracy, content, or fitness for any particular purpose or use of NYC DEP Clean Air Tracking System (CATS) Light Industrial Process Permit, or applications utilizing NYC DEP Clean Air Tracking System (CATS) Light Industrial Process Permit, provided by any third party. To obtain copies of DEP CATS Light Industrial Permits, please contact DEP's Bureau of Environmental Compliance.
+
+### **Update frequency**
+Monthly
+
+### **Date of last update**
+{{ date_last_update }}
+
+### **Date of underlying data**
+Pulled on {{ date_underlying_data }}

--- a/recipes/dep_cats_permits/build.py
+++ b/recipes/dep_cats_permits/build.py
@@ -144,8 +144,11 @@ def _readme():
 
     with open('README.md', 'r') as readme:
         template = Template(readme.read())
-        rendered = template.render(date_last_update='variables', date_underlying_data='here')
-    with open('_README.md', 'w') as _readme:
+        rendered = template.render(
+            date_last_update=date_last_update, 
+            date_underlying_data=date_underlying_data
+        )
+    with open('output/README.md', 'w') as _readme:
         _readme.write(rendered)
 
 if __name__ == "__main__":

--- a/recipes/dep_cats_permits/build.py
+++ b/recipes/dep_cats_permits/build.py
@@ -7,6 +7,9 @@ import re
 from _helper.geo import get_hnum, get_sname, clean_street, clean_house, clean_boro_name, \
                         find_stretch, find_intersection, geocode
 from multiprocessing import Pool, cpu_count
+import datetime as dt
+from jinja2 import Template
+import requests
 
 def _import() -> pd.DataFrame:
     url = "https://data.cityofnewyork.us/api/views/f4rp-2kvy/rows.csv"
@@ -134,9 +137,20 @@ def _output(df: pd.DataFrame):
     ]
     df[cols].to_csv(sys.stdout, sep="|", index=False)
 
+def _readme():
+    date_last_update=dt.datetime.today().strftime("%B %d, %Y")
+    metadata=requests.get('https://data.cityofnewyork.us/api/views/f4rp-2kvy.json').json()
+    date_underlying_data=dt.datetime.fromtimestamp(metadata['rowsUpdatedAt']).strftime("%B %d, %Y")
+
+    with open('README.md', 'r') as readme:
+        template = Template(readme.read())
+        rendered = template.render(date_last_update='variables', date_underlying_data='here')
+    with open('_README.md', 'w') as _readme:
+        _readme.write(rendered)
 
 if __name__ == "__main__":
 
     df = _import()
     df = _geocode(df)
+    _readme()
     _output(df)

--- a/recipes/dep_cats_permits/runner.sh
+++ b/recipes/dep_cats_permits/runner.sh
@@ -28,6 +28,11 @@ VERSION=$DATE
 
         # Write VERSION info
         echo "$VERSION" > version.txt
-        
+
+        # Convert README.md to README.pdf
+        docker run --rm\
+            -v "`pwd`:/data" \
+            --user `id -u`:`id -g` \
+            pandoc/latex README.md -o README.pdf
     )
 )


### PR DESCRIPTION
- updated docker-geosupport to include jinja2
- still need to convert markdown to README.pdf
- parsing metadata to extract last updated date
```python
metadata=requests.get('https://data.cityofnewyork.us/api/views/f4rp-2kvy.json').json()
```