### PR TITLE
adding open issue and close issue in dep-monthly.yml

### DIFF
--- a/.github/workflows/dep-monthly.yml
+++ b/.github/workflows/dep-monthly.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: nashmaniac/create-issue-action@v1.1
         name: Create Issue to Publish
         with:
-          title: [publish] dep_cats_permits
+          title: |
+            [publish] dep_cats_permits
           token: ${{secrets.GITHUB_TOKEN}}
           assignees: nnxka, sptkl
           labels: publish

--- a/.github/workflows/dep-monthly.yml
+++ b/.github/workflows/dep-monthly.yml
@@ -31,7 +31,7 @@ jobs:
           assignees: nnxka, sptkl
           labels: publish
           body: |
-            🎉 A fresh run of dep_cats_permits is complete !
+            A fresh run of dep_cats_permits is complete! 🎉
 
             ## Staging files output:
             - [ ] [version.txt](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/version.txt)

--- a/.github/workflows/dep-monthly.yml
+++ b/.github/workflows/dep-monthly.yml
@@ -4,18 +4,8 @@ on:
     - cron: 0 0 1 * *
   
 jobs:
-  issueCheck:
-    runs-on: ubuntu-latest
-    steps:
-      - if: startsWith(github.event.issue.title, '[publish] dep_cats_permits') != 'true'
-        name: Close Issue
-        uses: peter-evans/close-issue@v1
-        with:
-          comment: |
-            Previous version unpublished, closing, so that we can generate a new version
   build:
     runs-on: ubuntu-latest
-    needs: issueCheck
     env:
       RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
@@ -50,6 +40,6 @@ jobs:
             - [ ] [ReadMe_DEPCATS.pdf](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/ReadMe_DEPCATS.pdf)
 
             ## Next Steps: 
-            If you have manually checked above files and they seem to be ok, comment publish under this issue. 
+            If you have manually checked above files and they seem to be ok, comment `[publish]` under this issue. 
             This would allow github actions to move staging files to production. 
             Feel free to close this issue once it's all complete. Thanks!

--- a/.github/workflows/dep-monthly.yml
+++ b/.github/workflows/dep-monthly.yml
@@ -2,9 +2,20 @@ name: Run CEQR Recipe
 on:
   schedule:
     - cron: 0 0 1 * *
+  
 jobs:
+  issueCheck:
+    runs-on: ubuntu-latest
+    steps:
+      - if: startsWith(github.event.issue.title, '[publish] dep_cats_permits') != 'true'
+        name: Close Issue
+        uses: peter-evans/close-issue@v1
+        with:
+          comment: |
+            Previous version unpublished, closing, so that we can generate a new version
   build:
     runs-on: ubuntu-latest
+    needs: issueCheck
     env:
       RECIPE_ENGINE: ${{ secrets.RECIPE_ENGINE }}
       EDM_DATA: ${{ secrets.EDM_DATA }}
@@ -21,3 +32,24 @@ jobs:
       - name: Run recipe
         shell: bash
         run: ./ceqr run recipe dep_cats_permits
+  
+      - uses: nashmaniac/create-issue-action@v1.1
+        name: Create Issue to Publish
+        with:
+          title: [publish] dep_cats_permits
+          token: ${{secrets.GITHUB_TOKEN}}
+          assignees: nnxka, sptkl
+          labels: publish
+          body: |
+            🎉 A fresh run of dep_cats_permits is complete !
+
+            ## Staging files output:
+            - [ ] [version.txt](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/version.txt)
+            - [ ] [dep_cats_permits.zip](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/dep_cats_permits.zip)
+            - [ ] [dep_cats_permits.csv](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/dep_cats_permits.csv)
+            - [ ] [ReadMe_DEPCATS.pdf](https://nyc3.digitaloceanspaces.com/edm-publishing/ceqr-app-data-staging/dep_cats_permits/latest/ReadMe_DEPCATS.pdf)
+
+            ## Next Steps: 
+            If you have manually checked above files and they seem to be ok, comment publish under this issue. 
+            This would allow github actions to move staging files to production. 
+            Feel free to close this issue once it's all complete. Thanks!

--- a/.github/workflows/dep-monthly.yml
+++ b/.github/workflows/dep-monthly.yml
@@ -1,8 +1,9 @@
-name: Run CEQR Recipe
+name: Monthly Run DEP CATS permits
 on:
   schedule:
     - cron: 0 0 1 * *
-  
+  repository_dispatch:
+    types: [dep_cats_permits]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+name: Publish CEQR Recipe
+on:
+  issue_comment:
+    types: [created]
+  
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: >- 
+      contains(github.event.issue.title, '[publish]') && 
+      contains(github.event.comment.body, '[publish]') && 
+      github.event.comment.author_association == 'MEMBER'
+    env:
+      AWS_S3_ENDPOINT: ${{ secrets.AWS_S3_ENDPOINT }}
+      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    steps:
+      - uses: actions/checkout@v2
+        
+      - name: Install dependencies
+        shell: bash
+        run: ./ceqr setup
+        
+      - name: Run recipe
+        shell: bash
+        run: |
+          title='${{ github.event.issue.title }}'
+          recipes=$(python -c "print('$title').replace('[publish] ', '')")
+          for i in $(echo $recipes | tr " " "\n")
+          do
+            ./ceqr publish recipe $i
+          done
+                
+      - name: Success Message
+        if: success()
+        uses: peter-evans/create-or-update-comment@v1
+        with:
+          comment-id: ${{ github.event.comment.id }}
+          body: |
+            ## Publish Complete!
+            for more details, check https://github.com/NYCPlanning/ceqr-app-data/actions/runs/${{ github.run_id }}
+          reactions: hooray

--- a/recipes/_test/runner.sh
+++ b/recipes/_test/runner.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+source $(pwd)/bin/config.sh
+BASEDIR=$(dirname $0)
+NAME=$(basename $BASEDIR)
+VERSION=$DATE
+
+(
+    cd $BASEDIR
+
+    mkdir -p output && 
+    (
+        cd output
+
+        echo "a,b,c,d" > _test.csv
+        zip _test.csv.zip _test.csv
+        echo "a,b,c,d" > README.md
+        echo "a,b,c,d" > README.pdf
+        echo "data dictionary" > data_dictionary.xlsx
+
+        # Write VERSION info
+        echo "$VERSION" > version.txt
+        
+    )
+    Upload $NAME $VERSION
+    Upload $NAME latest
+    rm -rf output
+)

--- a/recipes/dep_cats_permits/runner.sh
+++ b/recipes/dep_cats_permits/runner.sh
@@ -33,8 +33,9 @@ VERSION=$DATE
         docker run --rm\
             -v "`pwd`:/data" \
             --user `id -u`:`id -g` \
-            pandoc/latex README.md -o README.pdf
+            pandoc/latex README.md -o ReadMe_DEPCATS.pdf
     )
     Upload $NAME $VERSION
     Upload $NAME latest
+    rm -rf output
 )


### PR DESCRIPTION
Workflow:
1. github actions running dep-cats-permits every month
2. creates a publish issue after each run and tags @nnxka 
3. @nnxka will then have to review the issue, check all the boxes, then comment [publish] under the issue to promote from staging to publishing
4. check everything is ok, then close issue