### PR TITLE
Pass correct .env variables to docker run

### DIFF
--- a/bin/config.sh
+++ b/bin/config.sh
@@ -13,11 +13,6 @@ function set_env {
 }
 set_env .env
 
-echo "EDM DATA is:"
-echo $EDM_DATA
-echo "DO S3 endpoint is:"
-echo $AWS_S3_ENDPOINT
-
 function urlparse {
     proto="$(echo $1 | grep :// | sed -e's,^\(.*://\).*,\1,g')"
     url=$(echo $1 | sed -e s,$proto,,g)

--- a/bin/config.sh
+++ b/bin/config.sh
@@ -13,6 +13,11 @@ function set_env {
 }
 set_env .env
 
+echo "EDM DATA is:"
+echo $EDM_DATA
+echo "DO S3 endpoint is:"
+echo $AWS_S3_ENDPOINT
+
 function urlparse {
     proto="$(echo $1 | grep :// | sed -e's,^\(.*://\).*,\1,g')"
     url=$(echo $1 | sed -e s,$proto,,g)

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -4,6 +4,5 @@ from datetime import date
 
 
 # CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
-print(f"environmental variables are f{os.environ}")
 EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -2,7 +2,5 @@ from sqlalchemy import create_engine
 import os
 from datetime import date
 
-
-CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
 EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -2,8 +2,7 @@ from sqlalchemy import create_engine
 import os
 from datetime import date
 
-edm_data_path = os.environ["EDM_DATA"]
-print(f"path loaded from secrets: {edm_data_path}")
-EDM_DATA = create_engine(os.environ["EDM_DATA"])
+
 CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
+EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -2,6 +2,8 @@ from sqlalchemy import create_engine
 import os
 from datetime import date
 
-EDM_DATA = create_engine(os.environ['EDM_DATA'])
-CEQR_DATA = create_engine(os.environ['CEQR_DATA'])
-DATE = date.today().strftime('%Y-%m-%d')
+edm_data_path = os.environ["EDM_DATA"]
+print(f"path loaded from secrets: {edm_data_path}")
+EDM_DATA = create_engine(os.environ["EDM_DATA"])
+CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
+DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -4,7 +4,6 @@ from datetime import date
 
 
 # CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
-print(f"EDM_DATA is f{os.environ['EDM_DATA']}")
-print(f"DO S3 endpoint is f{os.environ['AWS_S3_ENDPOINT']}")
+print(f"environmental variables are f{os.environ}")
 EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -3,6 +3,8 @@ import os
 from datetime import date
 
 
-CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
+# CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
+print(f"EDM_DATA is f{os.environ['EDM_DATA']}")
+print(f"DO S3 endpoint is f{os.environ['AWS_S3_ENDPOINT']}")
 EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -3,6 +3,6 @@ import os
 from datetime import date
 
 
-# CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
-# EDM_DATA = create_engine(os.environ["EDM_DATA"])
+CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
+EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/_helper/__init__.py
+++ b/recipes/_helper/__init__.py
@@ -4,5 +4,5 @@ from datetime import date
 
 
 # CEQR_DATA = create_engine(os.environ["CEQR_DATA"])
-EDM_DATA = create_engine(os.environ["EDM_DATA"])
+# EDM_DATA = create_engine(os.environ["EDM_DATA"])
 DATE = date.today().strftime("%Y-%m-%d")

--- a/recipes/dep_cats_permits/runner.sh
+++ b/recipes/dep_cats_permits/runner.sh
@@ -10,6 +10,7 @@ VERSION=$DATE
 
     docker run --rm\
         -e EDM_DATA=$EDM_DATA\
+        -e CEQR_DATA=$CEQR_DATA\
         -v $(pwd)/../:/recipes\
         -w /recipes/$NAME\
         --user $UID\

--- a/recipes/dep_cats_permits/runner.sh
+++ b/recipes/dep_cats_permits/runner.sh
@@ -9,6 +9,7 @@ VERSION=$DATE
     mkdir -p output
 
     docker run --rm\
+        -e EDM_DATA=$EDM_DATA\
         -v $(pwd)/../:/recipes\
         -w /recipes/$NAME\
         --user $UID\

--- a/recipes/dep_cats_permits/runner.sh
+++ b/recipes/dep_cats_permits/runner.sh
@@ -10,7 +10,6 @@ VERSION=$DATE
 
     docker run --rm\
         -e EDM_DATA=$EDM_DATA\
-        -e CEQR_DATA=$CEQR_DATA\
         -v $(pwd)/../:/recipes\
         -w /recipes/$NAME\
         --user $UID\

--- a/recipes/nysdec_state_facility_permits/runner.sh
+++ b/recipes/nysdec_state_facility_permits/runner.sh
@@ -10,7 +10,6 @@ VERSION=$DATE
     
     docker run --rm\
         -e EDM_DATA=$EDM_DATA\
-        -e CEQR_DATA=$CEQR_DATA\
         -v $(pwd)/../:/recipes\
         -e NAME=$NAME\
         -w /recipes/$NAME\


### PR DESCRIPTION
The docker run in `recipes/dep_cats_permits/runner.sh` wasn't passed necessary `$EDM_DATA` environmental variable to connect to the publishing database. 

Changes to `EDM_DATA` and `DATE`  in `recipes/_helper/__init__.py` are just from the auto-linter. `$CEQR_DATA` was removed as it's not used and there is no corresponding secret