### PR TITLE
Removing the publish label

### DIFF
--- a/.github/ISSUE_TEMPLATE/dep-monthly.md
+++ b/.github/ISSUE_TEMPLATE/dep-monthly.md
@@ -1,7 +1,6 @@
 ---
 name: Monthly Run DEP CATS permits
 title: dep_cats_permits
-labels: publish
 assignees: jpiacentinidcp, ileoyu, OmarOrtiz1
 ---
 A fresh run of dep_cats_permits is complete! 🎉


### PR DESCRIPTION
The label should not be appended at this stage in the workflow. It should be added by a data reviewer later.